### PR TITLE
設定画面のテキストを全て表示する対応

### DIFF
--- a/OneTimePasswordExample/Base.lproj/Main.storyboard
+++ b/OneTimePasswordExample/Base.lproj/Main.storyboard
@@ -17,7 +17,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="123456" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JX5-NB-jZf">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="123456" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="JX5-NB-jZf">
                                 <rect key="frame" x="20" y="227.5" width="374" height="77"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="64"/>
                                 <nil key="textColor"/>
@@ -88,21 +88,36 @@
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dkI-vG-V8f">
-                                            <rect key="frame" x="29" y="11" width="33" height="21"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dkI-vG-V8f">
+                                            <rect key="frame" x="30" y="11" width="170" height="20"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="170" id="J4w-Qf-Jlq"/>
+                                                <constraint firstAttribute="width" relation="lessThanOrEqual" constant="170" id="fvy-zA-QbD"/>
+                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="170" id="hgT-kM-o9n"/>
+                                                <constraint firstAttribute="height" constant="20" id="l9N-CY-eXa"/>
+                                            </constraints>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eJZ-98-6zi">
-                                            <rect key="frame" x="352" y="10" width="42" height="21"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="eJZ-98-6zi">
+                                            <rect key="frame" x="208" y="10" width="186" height="21"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="170" id="Kps-CC-oxP"/>
+                                                <constraint firstAttribute="width" constant="180" id="fLk-H6-Iom"/>
+                                            </constraints>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
+                                    <constraints>
+                                        <constraint firstItem="dkI-vG-V8f" firstAttribute="top" secondItem="DIh-8j-qZB" secondAttribute="topMargin" id="8ld-Oo-eOI"/>
+                                        <constraint firstItem="eJZ-98-6zi" firstAttribute="top" secondItem="DIh-8j-qZB" secondAttribute="topMargin" constant="-1" id="DYD-r1-cK1"/>
+                                        <constraint firstItem="eJZ-98-6zi" firstAttribute="leading" secondItem="dkI-vG-V8f" secondAttribute="trailing" constant="8" symbolic="YES" id="VSL-B3-n79"/>
+                                        <constraint firstItem="eJZ-98-6zi" firstAttribute="trailing" secondItem="DIh-8j-qZB" secondAttribute="trailingMargin" id="Y0a-2r-zVj"/>
+                                        <constraint firstItem="dkI-vG-V8f" firstAttribute="leading" secondItem="DIh-8j-qZB" secondAttribute="leadingMargin" constant="10" id="cmo-lk-kh6"/>
+                                    </constraints>
                                 </tableViewCellContentView>
                                 <connections>
                                     <outlet property="titleLabel" destination="dkI-vG-V8f" id="la4-97-ykA"/>

--- a/OneTimePasswordExample/Base.lproj/Main.storyboard
+++ b/OneTimePasswordExample/Base.lproj/Main.storyboard
@@ -88,12 +88,10 @@
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dkI-vG-V8f">
-                                            <rect key="frame" x="30" y="11" width="170" height="20"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="dkI-vG-V8f">
+                                            <rect key="frame" x="30" y="11" width="236" height="20"/>
                                             <constraints>
-                                                <constraint firstAttribute="width" constant="170" id="J4w-Qf-Jlq"/>
-                                                <constraint firstAttribute="width" relation="lessThanOrEqual" constant="170" id="fvy-zA-QbD"/>
-                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="170" id="hgT-kM-o9n"/>
+                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="130" id="eBC-ta-6ez"/>
                                                 <constraint firstAttribute="height" constant="20" id="l9N-CY-eXa"/>
                                             </constraints>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
@@ -101,10 +99,10 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="eJZ-98-6zi">
-                                            <rect key="frame" x="208" y="10" width="186" height="21"/>
+                                            <rect key="frame" x="274" y="10" width="120" height="20"/>
                                             <constraints>
-                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="170" id="Kps-CC-oxP"/>
-                                                <constraint firstAttribute="width" constant="180" id="fLk-H6-Iom"/>
+                                                <constraint firstAttribute="height" constant="20" id="PoQ-Bg-HPL"/>
+                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="fLk-H6-Iom"/>
                                             </constraints>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>


### PR DESCRIPTION
* [x] 対応する Issue が Linked Issues に設定されていることを確認してください

# 対応内容
設定画面のテキストを全て表示する対応
トークン表示画面のテキスト表示調節対応

# スクリーンショット
| before | after |
|-------|------|
|![simulator_screenshot_994C0A30-ACD8-4988-8ACD-B70E401415DF](https://user-images.githubusercontent.com/84489601/139457475-50ec0571-02bc-479c-a6d0-6c06c3695fae.png)| ![simulator_screenshot_3A5C01FC-2C22-4EAB-B301-7286B17CDEEA](https://user-images.githubusercontent.com/84489601/139456735-bb87cd6b-5a6a-4ad6-89d0-053702baa9ff.png)| 
|-------|------|
|![simulator_screenshot_3DE4B6FF-D818-43EE-99C4-3D822AD35968](https://user-images.githubusercontent.com/84489601/139457406-2de09708-c922-43fa-890b-badd1aa8a22e.png)|![simulator_screenshot_C6522044-980B-4029-87DA-16846A314B3A](https://user-images.githubusercontent.com/84489601/139456601-433b69c8-60ee-4c51-8089-b6f889bc3bbf.png)|

Closes #9 