### PR TITLE
OneTimePassword に関する変換処理を Converter に委譲する

### DIFF
--- a/OneTimePasswordExample.xcodeproj/project.pbxproj
+++ b/OneTimePasswordExample.xcodeproj/project.pbxproj
@@ -7,7 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		08804D92274BE72D00634C07 /* OneTimePasswordConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 08804D91274BE72D00634C07 /* OneTimePasswordConverter.m */; };
 		08804DA0274D283900634C07 /* OneTimePasswordSettingsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 08804D9F274D283900634C07 /* OneTimePasswordSettingsTests.m */; };
+		08804DA7274D3FA800634C07 /* OneTimePasswordConverterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 08804DA6274D3FA800634C07 /* OneTimePasswordConverterTest.m */; };
 		089ECCC427417C0400C7EAB8 /* OneTimePasswordSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = 089ECCC327417C0400C7EAB8 /* OneTimePasswordSettings.m */; };
 		08C8E26D26BBA376006D4608 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 08C8E26C26BBA376006D4608 /* AppDelegate.m */; };
 		08C8E27026BBA376006D4608 /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 08C8E26F26BBA376006D4608 /* SceneDelegate.m */; };
@@ -34,8 +36,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		08804D90274BE72D00634C07 /* OneTimePasswordConverter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneTimePasswordConverter.h; sourceTree = "<group>"; };
+		08804D91274BE72D00634C07 /* OneTimePasswordConverter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneTimePasswordConverter.m; sourceTree = "<group>"; };
 		08804D9D274D283900634C07 /* OneTimePasswordExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OneTimePasswordExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		08804D9F274D283900634C07 /* OneTimePasswordSettingsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneTimePasswordSettingsTests.m; sourceTree = "<group>"; };
+		08804DA6274D3FA800634C07 /* OneTimePasswordConverterTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneTimePasswordConverterTest.m; sourceTree = "<group>"; };
 		089ECCC227417C0400C7EAB8 /* OneTimePasswordSettings.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OneTimePasswordSettings.h; sourceTree = "<group>"; };
 		089ECCC327417C0400C7EAB8 /* OneTimePasswordSettings.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OneTimePasswordSettings.m; sourceTree = "<group>"; };
 		08C8E26826BBA376006D4608 /* OneTimePasswordExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OneTimePasswordExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -83,9 +88,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		08804D93274BF30000634C07 /* Converter */ = {
+			isa = PBXGroup;
+			children = (
+				08804D90274BE72D00634C07 /* OneTimePasswordConverter.h */,
+				08804D91274BE72D00634C07 /* OneTimePasswordConverter.m */,
+			);
+			path = Converter;
+			sourceTree = "<group>";
+		};
 		08804D9E274D283900634C07 /* OneTimePasswordExampleTests */ = {
 			isa = PBXGroup;
 			children = (
+				08804DA6274D3FA800634C07 /* OneTimePasswordConverterTest.m */,
 				08804D9F274D283900634C07 /* OneTimePasswordSettingsTests.m */,
 			);
 			path = OneTimePasswordExampleTests;
@@ -94,6 +109,7 @@
 		089ECCC127417BDA00C7EAB8 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				08804D93274BF30000634C07 /* Converter */,
 				089ECCC227417C0400C7EAB8 /* OneTimePasswordSettings.h */,
 				089ECCC327417C0400C7EAB8 /* OneTimePasswordSettings.m */,
 			);
@@ -314,6 +330,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				08804DA0274D283900634C07 /* OneTimePasswordSettingsTests.m in Sources */,
+				08804DA7274D3FA800634C07 /* OneTimePasswordConverterTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -322,6 +339,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				08C8E27326BBA376006D4608 /* ViewController.m in Sources */,
+				08804D92274BE72D00634C07 /* OneTimePasswordConverter.m in Sources */,
 				08C8E26D26BBA376006D4608 /* AppDelegate.m in Sources */,
 				4F8B41292705F8CF00CF6A1A /* SettingsTableViewCell.m in Sources */,
 				4F8B41252703520D00CF6A1A /* SettingController.m in Sources */,

--- a/OneTimePasswordExample/Model/Converter/OneTimePasswordConverter.h
+++ b/OneTimePasswordExample/Model/Converter/OneTimePasswordConverter.h
@@ -1,0 +1,26 @@
+//
+//  OneTimePasswordConverter.h
+//  OneTimePasswordExample
+//
+//  Created by KAWASHIMA Yoshiyuki on 2021/11/22.
+//
+
+#import <Foundation/Foundation.h>
+#import "OneTimePassword.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface OneTimePasswordConverter : NSObject
+
++ (NSString *)stringFromAlgorithm:(OTPAlgorithm)algorithm;
++ (NSString *)stringFromDigits:(NSUInteger)digits;
++ (NSString *)stringFromPeriod:(NSTimeInterval)period;
+
++ (NSData *)secretFromString:(NSString *)string;
++ (OTPAlgorithm)algorithmFromString:(NSString *)string;
++ (NSUInteger)digitisFromString:(NSString *)string;
++ (NSTimeInterval)periodFromString:(NSString *)string;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/OneTimePasswordExample/Model/Converter/OneTimePasswordConverter.m
+++ b/OneTimePasswordExample/Model/Converter/OneTimePasswordConverter.m
@@ -1,0 +1,41 @@
+//
+//  OneTimePasswrodConverter.m
+//  OneTimePasswordExample
+//
+//  Created by KAWASHIMA Yoshiyuki on 2021/11/22.
+//
+
+#import "OneTimePasswordConverter.h"
+#import <Base32/MF_Base32Additions.h>
+
+@implementation OneTimePasswordConverter
+
++ (NSString *)stringFromAlgorithm:(OTPAlgorithm)algorithm {
+    return [NSString stringForAlgorithm:algorithm];
+}
+
++ (NSString *)stringFromDigits:(NSUInteger)digits {
+    return [NSString stringWithFormat:@"%d", (int)digits];
+}
+
++ (NSString *)stringFromPeriod:(NSTimeInterval)period {
+    return [NSString stringWithFormat:@"%d", (int)period];
+}
+
++ (NSData *)secretFromString:(NSString *)string {
+    return [NSData dataWithBase32String:string.base32String];
+}
+
++ (OTPAlgorithm)algorithmFromString:(NSString *)string {
+    return [string algorithmValue];
+}
+
++ (NSUInteger)digitisFromString:(NSString *)string {
+    return [string intValue];
+}
+
++ (NSTimeInterval)periodFromString:(NSString *)string {
+    return [string intValue];
+}
+
+@end

--- a/OneTimePasswordExample/Model/OneTimePasswordSettings.m
+++ b/OneTimePasswordExample/Model/OneTimePasswordSettings.m
@@ -6,7 +6,7 @@
 //
 
 #import "OneTimePasswordSettings.h"
-#import <Base32/MF_Base32Additions.h>
+#import "OneTimePasswordConverter.h"
 
 @implementation OneTimePasswordSettings
 
@@ -20,9 +20,7 @@
         NSString *issuer = @"...";
         NSString *secretString = @"...";
 
-        NSData *secretData = [NSData dataWithBase32String:secretString];
-
-        sharedInstance.secretData = secretData;
+        sharedInstance.secretData = [OneTimePasswordConverter secretFromString:secretString];
         sharedInstance.name = name;
         sharedInstance.issuer = issuer;
         sharedInstance.algorithm = [OTPToken defaultAlgorithm];
@@ -41,27 +39,27 @@
 }
 
 - (NSString *)algorithmString {
-    return [NSString stringForAlgorithm:self.algorithm];
+    return [OneTimePasswordConverter stringFromAlgorithm:self.algorithm];
 }
 
 - (NSString *)digitsString {
-    return [NSString stringWithFormat:@"%d", (int)self.digits];
+    return [OneTimePasswordConverter stringFromDigits:self.digits];
 }
 
 - (NSString *)periodString {
-    return [NSString stringWithFormat:@"%d", (int)self.period];
+    return [OneTimePasswordConverter stringFromPeriod:self.period];
 }
 
 - (void)saveAlgorithmString:(NSString *)algorithmString {
-    self.algorithm = [algorithmString algorithmValue];
+    self.algorithm = [OneTimePasswordConverter algorithmFromString:algorithmString];
 }
 
 - (void)saveDigitsString:(NSString *)digitsString {
-    self.digits = [digitsString intValue];
+    self.digits = [OneTimePasswordConverter digitisFromString:digitsString];
 }
 
 - (void)savePeriodString:(NSString *)periodString {
-    self.period = [periodString intValue];
+    self.period = [OneTimePasswordConverter periodFromString:periodString];
 }
 
 @end

--- a/OneTimePasswordExampleTests/OneTimePasswordConverterTest.m
+++ b/OneTimePasswordExampleTests/OneTimePasswordConverterTest.m
@@ -1,0 +1,75 @@
+//
+//  OneTimePasswordConverterTest.m
+//  OneTimePasswordExampleTests
+//
+//  Created by KAWASHIMA Yoshiyuki on 2021/11/24.
+//
+
+#import <XCTest/XCTest.h>
+#import "OneTimePasswordConverter.h"
+#import "OneTimePassword.h"
+#import <Base32/MF_Base32Additions.h>
+
+@interface OneTimePasswordConverterTest : XCTestCase
+
+@end
+
+@implementation OneTimePasswordConverterTest
+
+- (void)setUp {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+}
+
+- (void)testStringFromAlgorithm {
+    XCTAssertEqualObjects(@"SHA1",   [OneTimePasswordConverter stringFromAlgorithm:OTPAlgorithmSHA1]);
+    XCTAssertEqualObjects(@"SHA256", [OneTimePasswordConverter stringFromAlgorithm:OTPAlgorithmSHA256]);
+    XCTAssertEqualObjects(@"SHA512", [OneTimePasswordConverter stringFromAlgorithm:OTPAlgorithmSHA512]);
+}
+
+- (void)testStringFromDigits {
+    XCTAssertEqualObjects(@"4",  [OneTimePasswordConverter stringFromDigits:4]);
+    XCTAssertEqualObjects(@"5",  [OneTimePasswordConverter stringFromDigits:5]);
+    XCTAssertEqualObjects(@"6",  [OneTimePasswordConverter stringFromDigits:6]);
+    XCTAssertEqualObjects(@"7",  [OneTimePasswordConverter stringFromDigits:7]);
+    XCTAssertEqualObjects(@"8",  [OneTimePasswordConverter stringFromDigits:8]);
+    XCTAssertEqualObjects(@"9",  [OneTimePasswordConverter stringFromDigits:9]);
+    XCTAssertEqualObjects(@"10", [OneTimePasswordConverter stringFromDigits:10]);
+}
+
+- (void)testStringFromPeriod {
+    XCTAssertEqualObjects(@"30", [OneTimePasswordConverter stringFromPeriod:30]);
+    XCTAssertEqualObjects(@"60", [OneTimePasswordConverter stringFromPeriod:60]);
+}
+
+- (void)testSecretFromString {
+    NSData *data = [OneTimePasswordConverter secretFromString:@"Test"];
+    NSString *decode = [MF_Base32Codec base32StringFromData:data];
+    XCTAssertEqualObjects(@"KRSXG5A=", decode);
+}
+
+- (void)testAlgorithmFromString {
+    XCTAssertEqual(OTPAlgorithmSHA1,   [OneTimePasswordConverter algorithmFromString:@"SHA1"]);
+    XCTAssertEqual(OTPAlgorithmSHA256, [OneTimePasswordConverter algorithmFromString:@"SHA256"]);
+    XCTAssertEqual(OTPAlgorithmSHA512, [OneTimePasswordConverter algorithmFromString:@"SHA512"]);
+}
+
+- (void)testDigitsFromString {
+    XCTAssertEqual(4,  [OneTimePasswordConverter digitisFromString:@"4"]);
+    XCTAssertEqual(5,  [OneTimePasswordConverter digitisFromString:@"5"]);
+    XCTAssertEqual(6,  [OneTimePasswordConverter digitisFromString:@"6"]);
+    XCTAssertEqual(7,  [OneTimePasswordConverter digitisFromString:@"7"]);
+    XCTAssertEqual(8,  [OneTimePasswordConverter digitisFromString:@"8"]);
+    XCTAssertEqual(9,  [OneTimePasswordConverter digitisFromString:@"9"]);
+    XCTAssertEqual(10, [OneTimePasswordConverter digitisFromString:@"10"]);
+}
+
+- (void)testPeriodFromString {
+    XCTAssertEqual(30, [OneTimePasswordConverter periodFromString:@"30"]);
+    XCTAssertEqual(60, [OneTimePasswordConverter periodFromString:@"60"]);
+}
+
+@end


### PR DESCRIPTION
* [x] 対応する Issue が Linked Issues に設定されていることを確認してください

# 対応内容
- OneTimePasswordConverter を追加
- OneTimePasswordConverter で置き換え
- OneTimePasswordConverterTest で壊れていないことを確認

# スクリーンショット
変更なし
